### PR TITLE
リンクの誤検知の改善、リダイレクトの検知

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "1.4.0",
     "image-size": "1.0.2",
     "markdown-it": "13.0.1",
+    "node-html-parser": "6.1.5",
     "prompts": "2.4.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const validate = async () => {
   const htmlText = toHtmlText(mdFile);
 
   // リンク切れチェック
-  void expiredLinkCheck(html);
+  void expiredLinkCheck(htmlText);
   // 容量チェック
   fileCapacityCheck(basePath);
   // アイキャッチの検証

--- a/src/logics/expiredLinkCheck/expiredLinkCheck.ts
+++ b/src/logics/expiredLinkCheck/expiredLinkCheck.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 import { printErrorLog } from "../../utils/printErrorLog";
 import { parse } from "node-html-parser";
 import { notNull } from "../../utils/notNull";
@@ -18,36 +18,31 @@ export const expiredLinkCheck = async (html: string) => {
   const requests = links.map(link => {
     return new Promise<Response>((resolve, reject) => {
       axios.get(link)
-        .then((res: AxiosResult) => resolve({ link: link, statusCode: res.status, statusText: res.statusText }))
+        .then((res: AxiosResponse) => {
+          const request = res.request as {res: {responseUrl: string}};
+          resolve({ link, resUrl: request.res.responseUrl });
+        })
         .catch((err: Error) => reject({ link: link, message: err.message }));
     });
   });
 
   // 並列で処理を行う
   const results = await Promise.allSettled(requests);
-  // status=200以外のものを抽出
-  const expired = results.filter(res => res.status === "rejected" || res.value.statusCode !== 200);
-
+  // リクエストが失敗したもの or リクエストのurlとレスポンスのurlが違うものを抽出
+  const expired = results.filter(res => res.status === "rejected" || res.value.resUrl !== res.value.link);
   // エラーメッセージを構築
   const messages = expired.map((ex) => {
     return ex.status === "rejected" ?
     // Promiseのrejected.reasonのany型を解決できなかったのでeslintを一時的にdisable
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       `${ex.reason.message as string} link:${ex.reason.link as string}` :
-      `${ex.value.statusCode.toString()} ${ex.value.statusText} link:${ex.value.link}`;
+      `リクエストとレスポンスのurlが異なっています。\nrequest:\n${ex.value.link}\nresponse:\n${ex.value.resUrl}`;
   });
-
   // ログ出力
   printErrorLog(["リンク切れのチェックを行います。"], messages);
 };
 
-type AxiosResult = {
-  status: number,
-  statusText: string,
-}
-
 type Response = {
   link: string,
-  statusCode: number,
-  statusText: string
+  resUrl: string
 }

--- a/src/logics/expiredLinkCheck/expiredLinkCheck.ts
+++ b/src/logics/expiredLinkCheck/expiredLinkCheck.ts
@@ -1,17 +1,18 @@
-import { notNull } from "../../utils/notNull";
 import axios from "axios";
 import { printErrorLog } from "../../utils/printErrorLog";
+import { parse } from "node-html-parser";
+import { notNull } from "../../utils/notNull";
 
 /**
  * htmlに変換した記事からアンカーリンクを抽出し、リンク切れになっていないかを検証します。
  * @param html html形式の記事
  */
-export const expiredLinkCheck = async (html: string[]) => {
-  // htmlからリンクを抽出
-  const links = html
-    .flatMap(content => content.split(/["']/)) // クオーテーションで分割する
-    .filter(notNull)
-    .filter(content => content.startsWith("http")); // httpで始まるもの = リンク本体 だけを抜き出す
+export const expiredLinkCheck = async (html: string) => {
+  const parsed = parse(html);
+  // リンクを抽出
+  const links = parsed.querySelectorAll("a")
+    .map((l) => l.getAttribute("href"))
+    .filter(notNull);
 
   // axiosでリクエストを送信する
   const requests = links.map(link => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
-    "lib": ["ESNext", "esnext.asynciterable"],
+    "lib": [
+      "ESNext",
+      "esnext.asynciterable",
+      "dom"
+    ],
     "sourceMap": false,
     "rootDir": "src",
     "strict": true,
@@ -15,7 +19,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "removeComments": true,
+    "removeComments": true
   },
   "includes": ["src"],
   "ts-node": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,7 +227,7 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz"
   integrity sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==
 
-"@types/prompts@^2.4.4":
+"@types/prompts@2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.4.4.tgz#dd5a1d41cb1bcd0fc4464bf44a0c8354f36ea735"
   integrity sha512-p5N9uoTH76lLvSAaYSZtBCdEXzpOOufsRjnhjVSrZGXikVGHX9+cc9ERtHRV4hvBKHyZb1bg4K+56Bd2TqUn4A==
@@ -560,6 +560,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -682,6 +687,22 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
@@ -718,6 +739,36 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 electron-to-chromium@^1.4.284:
   version "1.4.379"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.379.tgz#c9b597e090ce738e7a76db84e5678f27817bd644"
@@ -730,6 +781,11 @@ enhanced-resolve@^5.0.0, enhanced-resolve@^5.13.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@~3.0.1:
   version "3.0.1"
@@ -1043,6 +1099,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz"
@@ -1310,10 +1371,25 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+node-html-parser@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.5.tgz#c819dceb13a10a7642ff92f94f870b4f77968097"
+  integrity sha512-fAaM511feX++/Chnhe475a0NHD8M7AxDInsqQpz6x63GRF7xYNdS8Vo5dKsIVPgsOvG7eioRRTZQnWBrhDHBSg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
+
 node-releases@^2.0.8:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 once@^1.3.0:
   version "1.4.0"
@@ -1421,7 +1497,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prompts@^2.4.2:
+prompts@2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -1772,7 +1848,7 @@ webpack-node-externals@3.0.0:
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
   integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
 
-webpack-shebang-plugin@^1.1.8:
+webpack-shebang-plugin@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/webpack-shebang-plugin/-/webpack-shebang-plugin-1.1.8.tgz#007c8e01fab41362beb9305c9ce3c2adcee0936b"
   integrity sha512-8iHYp37XjytLuTkw8GCb4wm0s/0IWcv03YsfaDbOeRJfzSuBYVOadvc/QXQvr2b55pOEX1ANAEbz1fFSydJWVA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,7 +1371,7 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-html-parser@^6.1.5:
+node-html-parser@6.1.5:
   version "6.1.5"
   resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.5.tgz#c819dceb13a10a7642ff92f94f870b4f77968097"
   integrity sha512-fAaM511feX++/Chnhe475a0NHD8M7AxDInsqQpz6x63GRF7xYNdS8Vo5dKsIVPgsOvG7eioRRTZQnWBrhDHBSg==


### PR DESCRIPTION
@ics-sawada-h 

以下の対応を行いました。
ご確認をお願いします。

[Task7606: 記事校正支援ツール:リンクの誤検知の改善](https://dev.azure.com/icswebjp/3f5b8882-6641-4e7d-8a37-5899e1973bba/_workitems/edit/7606?tracking_data=eyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiJtcy52c3Mtd29yay5teS13b3JraXRlbS1hc3NpZ25lZC10by1jaGFuZ2VzLXN1YnNjcmlwdGlvbiIsIlNUeXBlIjoiQ09OIiwiUmVjaXAiOjEsIl94Y2kiOnsiTklEIjozNzMyNDg4MSwiTVJlY2lwIjoibTA9MSAiLCJBY3QiOiI0YTgzZjY0MS02NmEwLTRiOTYtOTkzNS0wYzc2Y2U3N2JjODUifSwiRWxlbWVudCI6Imhlcm8vY3RhIn0%3d)
[Task7605: 記事校正支援ツール：リダイレクトの検知](https://dev.azure.com/icswebjp/3f5b8882-6641-4e7d-8a37-5899e1973bba/_workitems/edit/7605?tracking_data=eyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiJtcy52c3Mtd29yay5teS13b3JraXRlbS1hc3NpZ25lZC10by1jaGFuZ2VzLXN1YnNjcmlwdGlvbiIsIlNUeXBlIjoiQ09OIiwiUmVjaXAiOjEsIl94Y2kiOnsiTklEIjozNzMyNDU5NywiTVJlY2lwIjoibTA9MSAiLCJBY3QiOiI3MWU3OGUxZi1mMGNmLTQzZTItOWJmYy03YWM2ZmY1MTdmNTUifSwiRWxlbWVudCI6Imhlcm8vY3RhIn0%3d)


## やったこと

### リンクの誤検知の改善
- `node-html-parser`を導入
- リンクの抽出時に`querySelectorAll()`でリンクを取得するように修正

### リダイレクトの検知
- チケットでは`node-fetch`で実装の提案がありましたが、node-fetchとts-nodeの相性が悪いらしくうまく動かなかったため、axiosのままで実装しました。
- `statusCode`での検知ではなく、`res.value.resUrl !== res.value.link`で検知を行っています。
- 記事ID`132`で実行すると以下のようなエラーメッセージが表示されます。

```sh
-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-
リンク切れのチェックを行います。
[Error]:リクエストとレスポンスのurlが異なっています。
request:
http://www.createjs.com/
response:
https://createjs.com/
[Error]:リクエストとレスポンスのurlが異なっています。
request:
http://www.typescriptlang.org/
response:
https://www.typescriptlang.org/
[Error]:リクエストとレスポンスのurlが異なっています。
request:
http://www.adobe.com/jp/products/flash/flash-to-html5.html
response:
https://helpx.adobe.com/jp/animate/using/creating-publishing-html5-canvas-document.html
[Error]:リクエストとレスポンスのurlが異なっています。
request:
http://www.typescriptlang.org/
response:
https://www.typescriptlang.org/
[Info]:終了
```